### PR TITLE
Include MathJax for LaTeX support

### DIFF
--- a/docs/TP2022-2023/TP_premieres_fonctions/tp_premieres_fonctions.md
+++ b/docs/TP2022-2023/TP_premieres_fonctions/tp_premieres_fonctions.md
@@ -52,7 +52,7 @@ racine carrée, en incluant le fichier d'en-tête `math.h`.
 
 
 **Exercice 4**:
-La célèbre conjecture de Syracuse énonce que, quel que soit l'entier strictement positif $N$, la suite définie par $u_0=N$ et
+La célèbre conjecture de Syracuse énonce que, quel que soit l'entier strictement positif $N$, la suite définie par $u_{0}=N$ et
 
 ```math
 u_{n+1} = \begin{cases}

--- a/docs/_includes/head-custom.html
+++ b/docs/_includes/head-custom.html
@@ -1,0 +1,9 @@
+<script type="text/x-mathjax-config">
+  MathJax.Hub.Config({
+    tex2jax: {
+      skipTags: ['script', 'noscript', 'style', 'textarea'],
+      inlineMath: [['$','$']]
+    }
+  });
+</script>
+<script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>


### PR DESCRIPTION
Ce commit devrait permettre au code LaTeX de s'afficher correctement.
Mes tests montrent que la plupart du code est correct:
[Github Page sur ma branche](https://liteapplication.github.io/mp2i-pv/TP2022-2023/TP_premieres_fonctions/tp_premieres_fonctions.html)

Je vois un seul problème dans la page : `$u_0=N$` est converti en \\(u_0=N\\)
Pour le reste, les formules ont l'air de s'afficher correctement

En espérant vous avoir fait gagner un peu de temps

Bon weekend